### PR TITLE
Improve types around reducers

### DIFF
--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -13,22 +13,22 @@ import LoginProvider from "../LoginProvider/LoginProvider";
 import Layout from "components/ui/Layout";
 import Home from "components/Home/Home";
 import TestRoutes from "routes/TestRoutes";
+import AppError from "errors/AppError";
 
 const App = () => {
-
-  const [appState, dispatch]: [any, Function] = useReducer(
+  const [appState, dispatch] = useReducer(
     appReducer,
     initialState
   );
 
-  const setAppError = (error)  => {
+  const setAppError = (error: AppError | null)  => {
     dispatch({
       type: "SET_ERROR",
       error
     });
   };
 
-  const setLocale = (locale) => {
+  const setLocale = (locale: string) => {
     dispatch({
       type: "SET_LOCALE",
       locale,

--- a/client/src/components/App/context.tsx
+++ b/client/src/components/App/context.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { AppState } from './reducer';
+import { AppAction, AppState } from './reducer';
 import { AppContainer } from './container';
+import AppError from 'errors/AppError';
 
 export interface AppContext {
   state: AppState;
-  setLocale: Function;
-  setAppError: Function;
-  dispatch: Function;
+  setLocale: (locale: string) => void;
+  setAppError: (error: AppError | null) => void;
+  dispatch: React.Dispatch<AppAction>;
   container: AppContainer;
 }
 

--- a/client/src/components/App/reducer.ts
+++ b/client/src/components/App/reducer.ts
@@ -5,6 +5,7 @@ import AppError from "errors/AppError";
 export interface AppState {
   locale: string;
   user?: any; // @TODO: Replace with proper typing once we know what our user data / auth flow looks like
+  error?: AppError;
 }
 
 export type AppAction = {
@@ -12,7 +13,7 @@ export type AppAction = {
   locale: string;
 } | {
   type: "SET_ERROR";
-  error: AppError;
+  error: AppError | null;
 } | {
   type: "LOGIN_SUCCESS";
   user: any;
@@ -26,28 +27,23 @@ export const initialState: AppState = {
 };
 
 export const appReducer: Reducer<AppState, AppAction> = (state, action): AppState => {
-  const handlers = {
-    SET_LOCALE: (state, action) => {
-      return { 
+  switch (action.type) {
+    case "SET_LOCALE":
+      return {
         ...state,
         locale: action.locale
       };
-    },
-    SET_ERROR: (state, action) => {
+    case "SET_ERROR":
       return { 
         ...state,
-        error: action.error
+        error: action.error || undefined
       };
-    },
-    LOGIN_SUCCESS: (state, action) => {
+    case "LOGIN_SUCCESS":
       return {
         ...state,
         user: action.user
       };
-    },
-    LOGOUT: () => {
+    case "LOGOUT":
       return initialState;
-    }
-  };
-  return handlers[action.type](state, action);
+  }
 };

--- a/client/src/components/TestContainer/TestContainer.tsx
+++ b/client/src/components/TestContainer/TestContainer.tsx
@@ -85,7 +85,7 @@ const TestContainerWrapper = (props: WrapperProps) => {
   
   const { children, step } = props;
 
-  const [testState, dispatch]: [any, Function] = useReducer(
+  const [testState, dispatch] = useReducer(
     testReducer,
     initialState
   );

--- a/client/src/components/TestContainer/context.tsx
+++ b/client/src/components/TestContainer/context.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { TestState } from './reducer';
+import { TestAction, TestState } from './reducer';
 
 export interface TestContext {
   state: TestState;
-  dispatch: Function;
+  dispatch: React.Dispatch<TestAction>;
 }
 
 const Context = React.createContext<TestContext | null>(null);

--- a/client/src/components/TestContainer/reducer.ts
+++ b/client/src/components/TestContainer/reducer.ts
@@ -15,13 +15,11 @@ export const initialState: TestState = {
 };
 
 export const testReducer: Reducer<TestState, TestAction> = (state, action): TestState => {
-  const handlers = {
-    SAVE_TEST: (state, action) => {
+  switch (action.type) {
+    case "SAVE_TEST":
       return {
         ...state,
         testRecord: action.testRecord
       };
-    }
-  };
-  return handlers[action.type](state, action);
+  }
 };


### PR DESCRIPTION
This is a suggestion for how to improve the types around your reducers, so
you get better type safety.  (My main goal was to remove the use of `any` and
`Function` types, which aren't very strict.)