### PR TITLE
Fix timer so it doesn't start with "9:60"

### DIFF
--- a/client/src/components/ui/Timer.tsx
+++ b/client/src/components/ui/Timer.tsx
@@ -116,8 +116,9 @@ export default (props: TimerProps) => {
   let label;
 
   if (!completed) {
-    const minutes = Math.floor(timeRemaining / 60000);
-    const seconds = Math.round((timeRemaining % 60000) / 1000);
+    const remainingSeconds = Math.ceil(timeRemaining / 1000);
+    const minutes = Math.floor(remainingSeconds / 60);
+    const seconds = remainingSeconds % 60;
     label = `${minutes | 0}:${seconds < 10 ? '0' + seconds : seconds}`;
   } else {
     label = 'DONE!';


### PR DESCRIPTION
This pulls over the timer fix from AudereNow/audere#666.

Around each minute boundary, the timer has a wonky behavior where it
temporarily shows a time like "3:60".

This happens because the current minute is calculated using `Math.floor()`,
while the current second is calculated using `Math.round()`.

I fixed this by first converting to an integer number of seconds.  Then the
remaining calculations are more straightforward.

I decided to use `Math.ceil()` here so that the timer has this sequence:
```
10:00 -> 9:59 -> ... -> 0:02 -> 0:01 -> DONE!
```
rather than:
```
9:59 -> 9:58 -> ... -> 0:01 -> 0:00 -> DONE!
```