### PR TITLE
update nhsuk-react-components and remove hotfix thats been fixed

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.15",
     "nhsuk-frontend": "^3.0.1",
-    "nhsuk-react-components": "1.2.0",
+    "nhsuk-react-components": "1.2.3",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-confirm-alert": "^2.6.1",

--- a/client/src/_sass/main.scss
+++ b/client/src/_sass/main.scss
@@ -1,8 +1,2 @@
 // NHS.UK frontend
 @import '~nhsuk-frontend/packages/nhsuk';
-
-// Hotfix to remove bottom margin from an incorrectly used class
-// https://github.com/NHSDigital/nhsuk-react-components/issues/28
-form.nhsuk-form-group--wrapper {
-  margin-bottom: 0;
-}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7561,10 +7561,10 @@ nhsuk-frontend@^3.0.1:
     accessible-autocomplete "^2.0.2"
     sass-mq "^5.0.1"
 
-nhsuk-react-components@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/nhsuk-react-components/-/nhsuk-react-components-1.2.0.tgz#d7d1e6a4dfee47a2c99380cc9b0d2a5c8fac3cbd"
-  integrity sha512-HJNM95S0GjAaQhhIhoaExARN3nNp4Qt12R4tZC8xs8z6lICnTVNw4ZIntqFcoB+cKdok2PrLRUAQ0oGNLOhtEQ==
+nhsuk-react-components@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/nhsuk-react-components/-/nhsuk-react-components-1.2.3.tgz#4a0def4c567ee7c21cfb7ab53f052e86c58155bb"
+  integrity sha512-pttrm+/yrD2PysaH8TfORGtJypXfS4gqa3vzzNMCFu0RFxmNbYCETCAotFcij1QHcg7VGxs8LiFGazaLekZnvA==
   dependencies:
     classnames "^2.2.6"
 


### PR DESCRIPTION
- Update nhsuk-react-components to the latest version (v1.2.3)

> - Fixes an issue where the `nhsuk-form-group--wrapper` was being applied to the Form component where it should not have been
> - Allows passing of custom props to the `<div class="nhsuk-form-group">` in any form element
> - Fixes an issue where the disableErrorFromComponents prop disabled displaying the error text as well as the error line - 

- Remove custom hotfix for the `nhsuk-form-group--wrapper` that has now been fixed in the above version