### PR TITLE
[LDAT-138] Prevent closing the application during tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "nhsuk-frontend": "^3.0.1",
     "nhsuk-react-components": "1.2.3",
     "react": "^16.13.1",
+    "react-beforeunload": "^2.2.2",
     "react-confirm-alert": "^2.6.1",
     "react-cookie": "^4.0.3",
     "react-dom": "^16.13.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9776,6 +9776,14 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
+react-beforeunload@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-beforeunload/-/react-beforeunload-2.2.2.tgz#35a99311284ecbc497a269347a5a9bb0ae21dffd"
+  integrity sha512-U2ZMbVj58ziIYEwQAKJTsCbe9jXyltnKIrU47OTqk8amXzopL/S4fK7kqg0ph8O4aQoSy5ydvKL+KLg+jIUe0Q==
+  dependencies:
+    prop-types "^15.7.2"
+    use-latest "^1.1.0"
+
 react-confirm-alert@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/react-confirm-alert/-/react-confirm-alert-2.6.1.tgz#ab870eea77131547daabe2b97f6cd528ca4d921d"
@@ -11891,6 +11899,18 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-isomorphic-layout-effect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.0.0.tgz#f56b4ed633e1c21cd9fc76fe249002a1c28989fb"
+  integrity sha512-JMwJ7Vd86NwAt1jH7q+OIozZSIxA4ND0fx6AsOe2q1H8ooBUp5aN6DvVCqZiIaYU6JaMRJGyR0FO7EBCIsb/Rg==
+
+use-latest@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.1.0.tgz#7bf9684555869c3f5f37e10d0884c8accf4d3aa6"
+  integrity sha512-gF04d0ZMV3AMB8Q7HtfkAWe+oq1tFXP6dZKwBHQF5nVXtGsh2oAYeeqma5ZzxtlpOcW8Ro/tLcfmEodjDeqtuw==
+  dependencies:
+    use-isomorphic-layout-effect "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Context

In order to prevent users closing the application before submitting their test result, we want to prevent them closing the page without a warning prompting them first.

## Changes proposed in this pull request

- Use the `react-beforeunload` library to hook into the `beforeunload` event and display a message.
  - Due to the limitations of browsers, it's not possible to customise this message as the behaviour is deprecated.
- Make the user prompted for confirmation when attempting to close the app anywhere but the login page and the final step.

## Guidance to review

- Check out the branch
- Runthrough the test flow, and attempt to close it at multiple points
- Attempt to close the flow on the final screen

## Link to Jira task

https://bluesquirrel.atlassian.net/browse/LDAT-138

<!-- ## Things to check - omitted for now 

- [ ] Example to check
- [ ] Example two

-->

