### PR TITLE
[LDAT-35] Store photo upload time for users

### DIFF
--- a/lib/dist/models/TestRecord.d.ts
+++ b/lib/dist/models/TestRecord.d.ts
@@ -5,6 +5,7 @@ export default interface TestRecord {
     downloadUrl: string;
     step: string;
     timerStartedAt: number;
+    photoUploadedAt?: number;
     predictionData?: PredictionData;
     testCompleted: boolean;
     result?: PredictionResult;

--- a/lib/models/TestRecord.ts
+++ b/lib/models/TestRecord.ts
@@ -6,6 +6,7 @@ export default interface TestRecord {
   downloadUrl: string; // signed s3 url the user uses to review their uploaded image
   step: string; // name of the latest step reached
   timerStartedAt: number; // timestamp when the test begins to react
+  photoUploadedAt?: number; // timestamp when the user uploads the photo
   predictionData?: PredictionData, // data returned from the ml model
   testCompleted: boolean, // Has the user successfully uploaded an image that met the criteria
   result?: PredictionResult, // Pull our result from prediction data to top level

--- a/take-test-app/src/components/FileUploader/PhotoPreview.tsx
+++ b/take-test-app/src/components/FileUploader/PhotoPreview.tsx
@@ -107,6 +107,14 @@ export default (props: PhotoPreviewProps) => {
             return;
           }
           setUploadingState(UPLOADING_STATES.DONE);
+
+          await testApi.updateTest({
+            testRecord: {
+              ...testRecord,
+              photoUploadedAt: Date.now()
+            }
+          });
+
         } else {
           if (isCancelled) {
             return;
@@ -123,6 +131,7 @@ export default (props: PhotoPreviewProps) => {
         if (isCancelled) {
           return;
         }
+
         setAppError({
           code: "UPL1",
           onFix: handleRetry,

--- a/take-test-app/src/components/FileUploader/__tests__/PhotoPreview.test.tsx
+++ b/take-test-app/src/components/FileUploader/__tests__/PhotoPreview.test.tsx
@@ -127,6 +127,17 @@ describe("<PhotoPreview>", () => {
     expect(api.interpretResult).toHaveBeenCalled();
   });
 
+  it("updates the test with the time uploaded if uploaded successfully", async () => {
+    const api = {
+      interpretResult: jest.fn(),
+      uploadImage: jest.fn(() => Promise.resolve()),
+      updateTest: jest.fn(() => Promise.resolve())
+    };
+    await renderPhotoPreview({ api });
+    await submitPhoto();
+    expect(api.updateTest).toHaveBeenCalled();
+  });
+
   it("attempts to interpret the image if uploaded successfully", async () => {
     const api = {
       interpretResult: jest.fn(),


### PR DESCRIPTION
## Context

In order to understand whether or not photos are taken long enough after the initial timer expires to cause issues, we need to track the time the image is actually uploaded.

## Changes proposed in this pull request

- Store the time the image is uploaded successfully in the test record

## Guidance to review

- Upload a photo
- Ensure the time uploaded at was stored correctly

## Link to Jira task

https://bluesquirrel.atlassian.net/browse/LDAT-35

<!-- ## Things to check - omitted for now 

- [ ] Example to check
- [ ] Example two

-->

