### PR TITLE
[LDAT-146/182/64] Add tests to testApi

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -69,6 +69,7 @@
     "@types/uuid": "^7.0.3",
     "jest": "^24.0.0",
     "jest-puppeteer": "^4.4.0",
+    "nock": "^13.0.2",
     "node-sass": "^4.14.1",
     "puppeteer": "^3.3.0",
     "ts-jest": "^26.1.0",

--- a/client/src/api/__tests__/testApi.test.ts
+++ b/client/src/api/__tests__/testApi.test.ts
@@ -55,9 +55,7 @@ describe("TestApi", () => {
     });
 
     it("Returns the response from the update endpoint", async () => {
-      nock(apiBase)
-        .post("/generate")
-        .reply(200, { an: "example" });
+      nock(apiBase).post("/generate").reply(200, { an: "example" });
 
       const response = await testApi({
         apiBase: apiBase,
@@ -67,10 +65,8 @@ describe("TestApi", () => {
     });
 
     testErrors({
-      stubRequest: () =>
-        nock(apiBase).post("/generate").reply(404),
-      callApi: () =>
-        testApi({ apiBase: apiBase }).generateTest(),
+      stubRequest: () => nock(apiBase).post("/generate").reply(404),
+      callApi: () => testApi({ apiBase: apiBase }).generateTest(),
       expectedErrorCode: 404,
     });
   });
@@ -103,14 +99,62 @@ describe("TestApi", () => {
 
     testErrors({
       stubRequest: () =>
-        nock(apiBase)
-          .post("/update", { dog: "woof" })
-          .reply(403),
+        nock(apiBase).post("/update", { dog: "woof" }).reply(403),
       callApi: () =>
         testApi({ apiBase: apiBase }).updateTest({
           dog: "woof",
         }),
       expectedErrorCode: 403,
+    });
+  });
+
+  describe("uploadImage", () => {
+    it("puts the given file on the URL", async () => {
+      const uploadRequest = nock("https://meow.cat")
+        .put("/example", "File")
+        .reply(200);
+
+      await testApi({ apiBase }).uploadImage(
+        "https://meow.cat/example",
+        "File",
+        () => {}
+      );
+
+      expect(uploadRequest.isDone()).toEqual(true);
+    });
+
+    describe("content-types", () => {
+      it("Uploads a file with its specified type", async () => {
+        const fileToUpload = new File(["a"], "file", { type: "image/jpeg" });
+        const uploadRequest = nock("https://meow.cat")
+          .put("/example", "a")
+          .matchHeader("content-type", "image/jpeg")
+          .reply(200);
+
+        await testApi({ apiBase }).uploadImage(
+          "https://meow.cat/example",
+          fileToUpload,
+          () => {}
+        );
+
+        expect(uploadRequest.isDone()).toEqual(true);
+      });
+
+      it("Defaults to image/png when no type is given", async () => {
+        const fileToUpload = new File(["a"], "file");
+        const uploadRequest = nock("https://meow.cat")
+          .put("/example", "a")
+          .matchHeader("content-type", "image/png")
+          .reply(200);
+
+        await testApi({ apiBase }).uploadImage(
+          "https://meow.cat/example",
+          fileToUpload,
+          () => {}
+        );
+
+        expect(uploadRequest.isDone()).toEqual(true);
+      });
     });
   });
 
@@ -127,9 +171,7 @@ describe("TestApi", () => {
     });
 
     it("Returns the response from the update endpoint", async () => {
-      nock(apiBase)
-        .post("/interpret")
-        .reply(200, { an: "example" });
+      nock(apiBase).post("/interpret").reply(200, { an: "example" });
 
       const response = await testApi({
         apiBase: apiBase,
@@ -139,10 +181,8 @@ describe("TestApi", () => {
     });
 
     testErrors({
-      stubRequest: () =>
-        nock(apiBase).post("/interpret").reply(404),
-      callApi: () =>
-        testApi({ apiBase: apiBase }).interpretResult(),
+      stubRequest: () => nock(apiBase).post("/interpret").reply(404),
+      callApi: () => testApi({ apiBase: apiBase }).interpretResult(),
       expectedErrorCode: 404,
     });
   });

--- a/client/src/api/__tests__/testApi.test.ts
+++ b/client/src/api/__tests__/testApi.test.ts
@@ -1,0 +1,83 @@
+import testApi, { HTTPError } from "../testApi";
+import nock from "nock";
+
+jest.mock("js-cookie", () => ({
+  get: () => "stubCookie",
+}));
+
+describe("TestApi", () => {
+  const apiBase = "https://meow.cat/dev";
+
+  const testErrors = ({ stubRequest, callApi, expectedErrorCode }) => {
+    describe("returning errors", () => {
+      it("Throws an error", async () => {
+        stubRequest();
+        await expect(callApi()).rejects.toThrow(HTTPError);
+      });
+
+      it("Returns the status code in the error", async () => {
+        stubRequest();
+        let error: HTTPError | undefined;
+
+        try {
+          await callApi();
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).not.toBeUndefined();
+        expect(error?.statusCode).toBe(expectedErrorCode);
+      });
+    });
+  };
+
+  beforeEach(() => {
+    nock(apiBase).options(/.*/).reply(
+      200,
+      {},
+      {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Authorization, Content-Type",
+      }
+    );
+  });
+
+  describe("/update", () => {
+    it("Passes the parameters & cookie to the update endpoint", async () => {
+      const updateRequest = nock("https://meow.cat/dev")
+        .post("/update", { dog: "woof" })
+        .matchHeader("Authorization", "stubCookie")
+        .reply(200, {});
+
+      await testApi({ apiBase: "https://meow.cat/dev" }).updateTest({
+        dog: "woof",
+      });
+
+      expect(updateRequest.isDone()).toBe(true);
+    });
+
+    it("Returns the response from the update endpoint", async () => {
+      nock("https://meow.cat/dev")
+        .post("/update", { dog: "woof" })
+        .reply(200, { an: "example" });
+
+      const response = await testApi({
+        apiBase: "https://meow.cat/dev",
+      }).updateTest({ dog: "woof" });
+
+      expect(response).toEqual({ an: "example" });
+    });
+
+    testErrors({
+      stubRequest: () =>
+        nock("https://meow.cat/dev")
+          .post("/update", { dog: "woof" })
+          .reply(403),
+      callApi: () =>
+        testApi({ apiBase: "https://meow.cat/dev" }).updateTest({
+          dog: "woof",
+        }),
+      expectedErrorCode: 403,
+    });
+  });
+});

--- a/client/src/api/__tests__/testApi.test.ts
+++ b/client/src/api/__tests__/testApi.test.ts
@@ -42,6 +42,41 @@ describe("TestApi", () => {
     );
   });
 
+  describe("/generate", () => {
+    it("Passes the cookie to the generate endpoint", async () => {
+      const updateRequest = nock("https://meow.cat/dev")
+        .post("/generate")
+        .matchHeader("Authorization", "stubCookie")
+        .reply(200, {});
+
+      await testApi({ apiBase: "https://meow.cat/dev" }).generateTest();
+
+      expect(updateRequest.isDone()).toBe(true);
+    });
+
+    it("Returns the response from the update endpoint", async () => {
+      nock("https://meow.cat/dev")
+        .post("/generate")
+        .reply(200, { an: "example" });
+
+      const response = await testApi({
+        apiBase: "https://meow.cat/dev",
+      }).generateTest();
+
+      expect(response).toEqual({ an: "example" });
+    });
+
+    testErrors({
+      stubRequest: () =>
+        nock("https://meow.cat/dev")
+          .post("/generate")
+          .reply(404),
+      callApi: () =>
+        testApi({ apiBase: "https://meow.cat/dev" }).generateTest(),
+      expectedErrorCode: 404,
+    });
+  });
+
   describe("/update", () => {
     it("Passes the parameters & cookie to the update endpoint", async () => {
       const updateRequest = nock("https://meow.cat/dev")

--- a/client/src/api/__tests__/testApi.test.ts
+++ b/client/src/api/__tests__/testApi.test.ts
@@ -44,23 +44,23 @@ describe("TestApi", () => {
 
   describe("/generate", () => {
     it("Passes the cookie to the generate endpoint", async () => {
-      const updateRequest = nock("https://meow.cat/dev")
+      const generateRequest = nock(apiBase)
         .post("/generate")
         .matchHeader("Authorization", "stubCookie")
         .reply(200, {});
 
-      await testApi({ apiBase: "https://meow.cat/dev" }).generateTest();
+      await testApi({ apiBase: apiBase }).generateTest();
 
-      expect(updateRequest.isDone()).toBe(true);
+      expect(generateRequest.isDone()).toBe(true);
     });
 
     it("Returns the response from the update endpoint", async () => {
-      nock("https://meow.cat/dev")
+      nock(apiBase)
         .post("/generate")
         .reply(200, { an: "example" });
 
       const response = await testApi({
-        apiBase: "https://meow.cat/dev",
+        apiBase: apiBase,
       }).generateTest();
 
       expect(response).toEqual({ an: "example" });
@@ -68,23 +68,21 @@ describe("TestApi", () => {
 
     testErrors({
       stubRequest: () =>
-        nock("https://meow.cat/dev")
-          .post("/generate")
-          .reply(404),
+        nock(apiBase).post("/generate").reply(404),
       callApi: () =>
-        testApi({ apiBase: "https://meow.cat/dev" }).generateTest(),
+        testApi({ apiBase: apiBase }).generateTest(),
       expectedErrorCode: 404,
     });
   });
 
   describe("/update", () => {
     it("Passes the parameters & cookie to the update endpoint", async () => {
-      const updateRequest = nock("https://meow.cat/dev")
+      const updateRequest = nock(apiBase)
         .post("/update", { dog: "woof" })
         .matchHeader("Authorization", "stubCookie")
         .reply(200, {});
 
-      await testApi({ apiBase: "https://meow.cat/dev" }).updateTest({
+      await testApi({ apiBase: apiBase }).updateTest({
         dog: "woof",
       });
 
@@ -92,12 +90,12 @@ describe("TestApi", () => {
     });
 
     it("Returns the response from the update endpoint", async () => {
-      nock("https://meow.cat/dev")
+      nock(apiBase)
         .post("/update", { dog: "woof" })
         .reply(200, { an: "example" });
 
       const response = await testApi({
-        apiBase: "https://meow.cat/dev",
+        apiBase: apiBase,
       }).updateTest({ dog: "woof" });
 
       expect(response).toEqual({ an: "example" });
@@ -105,14 +103,47 @@ describe("TestApi", () => {
 
     testErrors({
       stubRequest: () =>
-        nock("https://meow.cat/dev")
+        nock(apiBase)
           .post("/update", { dog: "woof" })
           .reply(403),
       callApi: () =>
-        testApi({ apiBase: "https://meow.cat/dev" }).updateTest({
+        testApi({ apiBase: apiBase }).updateTest({
           dog: "woof",
         }),
       expectedErrorCode: 403,
+    });
+  });
+
+  describe("/interpret", () => {
+    it("Passes the cookie to the generate endpoint", async () => {
+      const interpretRequest = nock(apiBase)
+        .post("/interpret")
+        .matchHeader("Authorization", "stubCookie")
+        .reply(200, {});
+
+      await testApi({ apiBase: apiBase }).interpretResult();
+
+      expect(interpretRequest.isDone()).toBe(true);
+    });
+
+    it("Returns the response from the update endpoint", async () => {
+      nock(apiBase)
+        .post("/interpret")
+        .reply(200, { an: "example" });
+
+      const response = await testApi({
+        apiBase: apiBase,
+      }).interpretResult();
+
+      expect(response).toEqual({ an: "example" });
+    });
+
+    testErrors({
+      stubRequest: () =>
+        nock(apiBase).post("/interpret").reply(404),
+      callApi: () =>
+        testApi({ apiBase: apiBase }).interpretResult(),
+      expectedErrorCode: 404,
     });
   });
 });

--- a/client/src/api/testApi.ts
+++ b/client/src/api/testApi.ts
@@ -1,8 +1,6 @@
-import config from './config';
 import { GenerateTestResponse } from 'abt-lib/requests/GenerateTest';
 import { UpdateTestRequest, UpdateTestResponse } from 'abt-lib/requests/UpdateTest';
 import cookies from 'js-cookie';
-const { apiBase } = config;
 
 export interface TestApi {
   generateTest(): Promise<GenerateTestResponse>;
@@ -36,7 +34,7 @@ function handleErrors(response: Response): Response {
   return response;
 }
 
-const testApi: TestApi = {
+const testApi = ({ apiBase }: { apiBase: string}): TestApi => ({
   generateTest: async (): Promise<GenerateTestResponse> => {
     const response = await fetch(`${apiBase}/generate`, {
       method: "POST",
@@ -103,6 +101,6 @@ const testApi: TestApi = {
     }).then(handleErrors);
     return response.json();
   }
-};
+});
 
 export default testApi;

--- a/client/src/components/App/container.ts
+++ b/client/src/components/App/container.ts
@@ -1,5 +1,6 @@
 import login from "../../usecases/login";
 import testApi, { TestApi } from "api/testApi";
+import apiConfig from "api/config";
 
 
 export interface AppContainer {
@@ -13,6 +14,6 @@ export class AppContainer implements AppContainer {
   }
 
   getTestApi() {
-    return testApi;
+    return testApi({ apiBase: apiConfig.apiBase });
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2071,7 +2071,7 @@ abt-lib@./../lib:
   version "0.1.3"
   dependencies:
     "@types/lodash" "^4.14.155"
-    lodash "^4.17.15"
+    lodash "^4.17.19"
     rimraf "^3.0.2"
 
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
@@ -7117,7 +7117,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -7438,6 +7438,11 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -7467,6 +7472,11 @@ lodash.uniq@^4.5.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 loglevel@^1.6.6:
   version "1.6.7"
@@ -7999,6 +8009,16 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
+
+nock@^13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.2.tgz#3e50f88348edbb90cce1bbbf0a3ea6a068993983"
+  integrity sha512-Wm8H22iT3UKPDf138tmgJ0NRfCLd9f2LByki9T2mGHnB66pEqvJh3gV/up1ZufZF24n7/pDYyLGybdqOzF3JIw==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -9577,6 +9597,11 @@ prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proxy-addr@~2.0.5:
   version "2.0.6"


### PR DESCRIPTION
## Context

Files without direct unit testing (due to the early pace of development) need to have tests written around them, this adds tests to the `testApi` 

## Changes proposed in this pull request

- Add `nock` to allow for web request intercepting for tests
- Pass `apiBase` to `testApi` to allow for testing
- Add tests for all methods in `testApi`

## Guidance to review

- N/A

## Link to Jira task

- https://bluesquirrel.atlassian.net/browse/LDAT-64
- https://bluesquirrel.atlassian.net/browse/LDAT-146
- https://bluesquirrel.atlassian.net/browse/LDAT-182
