### PR TITLE
[LDAT-146] Fix infinite putting of images

### DIFF
--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -9,7 +9,7 @@ import { appReducer, initialState } from "./reducer";
 import messages from "i18n/index";
 import ErrorBoundary from 'components/ErrorBoundary/ErrorBoundary';
 import flatten from 'flat';
-import { AppContainer } from "./container";
+import AppContainer from "./container";
 import LoginProvider from "../LoginProvider/LoginProvider";
 import Layout from "components/ui/Layout";
 import Home from "components/Home/Home";

--- a/client/src/components/App/__tests__/container.test.ts
+++ b/client/src/components/App/__tests__/container.test.ts
@@ -1,0 +1,12 @@
+import AppContainer from "../container";
+
+describe("AppContainer", () => {
+  describe("getTestApi", () => {
+    it("Always returns the same instance", () => {
+      const container = new AppContainer();
+      const instanceOne = container.getTestApi();
+      const instanceTwo = container.getTestApi();
+      expect(instanceOne).toEqual(instanceTwo);
+    });
+  });
+});

--- a/client/src/components/App/container.ts
+++ b/client/src/components/App/container.ts
@@ -2,18 +2,28 @@ import login from "../../usecases/login";
 import testApi, { TestApi } from "api/testApi";
 import apiConfig from "api/config";
 
-
 export interface AppContainer {
   getLogin(): Function;
   getTestApi(): TestApi;
 }
 
-export class AppContainer implements AppContainer {
-  getLogin() {
-    return login();
+export default class Container implements AppContainer {
+  private testApi: undefined | TestApi;
+
+  constructor() {
+    this.testApi = undefined;
   }
 
-  getTestApi() {
-    return testApi({ apiBase: apiConfig.apiBase });
-  }
+  getLogin = () => {
+    return login();
+  };
+
+  getTestApi = () => {
+    if (this.testApi) {
+      return this.testApi;
+    } else {
+      this.testApi = testApi({ apiBase: apiConfig.apiBase });
+      return this.testApi;
+    }
+  };
 }

--- a/client/src/utils/testUtils.tsx
+++ b/client/src/utils/testUtils.tsx
@@ -28,7 +28,7 @@ export const defaultRecord: TestRecord = {
 /* Renduces boilerplate in tests by passing partial properties to the stub context to overwrite the defaults */
 export const renderWithStubTestContext = (component: JSX.Element, api = {}, recordProperties: Partial<TestRecord>): [RenderResult, AppContextType, TestContextType] => {
 
-  const testContext : TestContextType = {
+  const testContext: TestContextType = {
     state: {
       testRecord: { ...defaultRecord, ...recordProperties }
     },
@@ -56,7 +56,7 @@ export const renderWithStubAppContext = (component, api = {}): [RenderResult, Ap
 
 
 
-  const appContext = {
+  const appContext: AppContextType = {
     state: { locale: "en-gb" },
     setLocale: () => { },
     setAppError: () => { },


### PR DESCRIPTION
## Context

When uploading a photo, although they were uploaded successfully - it would loop infinitely. Investigation showed that this was due to the change where `testApi` was now the result of a function call, not just a reference. This meant every render things were changing - and causing the request to send again.

## Changes proposed in this pull request

- Cache the `testApi` in the container, preventing multiple instances of it being created.

## Guidance to review

- Attempt to upload a picture, check the network tab, and ensure only one request is sent.

## Link to Jira task

https://bluesquirrel.atlassian.net/browse/LDAT-146