### PR TITLE
[LDAT-250] enqueue images

### DIFF
--- a/api/api/review.ts
+++ b/api/api/review.ts
@@ -1,0 +1,25 @@
+import TestRecord from "abt-lib/models/TestRecord";
+
+import config from '../config';
+import AWS from 'aws-sdk';
+
+export const reviewIfRequired = async (testRecord : TestRecord) : Promise<Boolean> => {
+
+  // Considering the quantity of images coming in we can just do this stochastically rather than incrementing a counter
+
+  if (Math.random() < config.reviewChance) {
+    await review(testRecord);
+    return true;
+  } else {
+    return false;
+  }
+};
+
+const review = async (testRecord: TestRecord) => {
+  const SQS = new AWS.SQS();
+  const queueUrl = "https://sqs.eu-west-2.amazonaws.com/877130379437/results";
+  return await SQS.sendMessage({
+    QueueUrl: queueUrl,
+    MessageBody: testRecord.guid
+  }).promise();
+};

--- a/api/api/review.ts
+++ b/api/api/review.ts
@@ -17,9 +17,12 @@ export const reviewIfRequired = async (testRecord : TestRecord) : Promise<Boolea
 
 const review = async (testRecord: TestRecord) => {
   const SQS = new AWS.SQS();
-  const queueUrl = "https://sqs.eu-west-2.amazonaws.com/877130379437/results";
+  const queueUrl = await SQS.getQueueUrl({
+    QueueName: process.env.REVIEW_QUEUE_NAME!
+  }).promise();
+    
   return await SQS.sendMessage({
-    QueueUrl: queueUrl,
+    QueueUrl: queueUrl.QueueUrl!,
     MessageBody: testRecord.guid
   }).promise();
 };

--- a/api/config.ts
+++ b/api/config.ts
@@ -7,5 +7,6 @@ export default {
   apiBase: `${process.env.REACT_APP_API_BASE}/${process.env.REACT_APP_STAGE}`,
   localFilePath: '/tmp/',
   rdtImagePath: 'rdt-images/',
-  modelPath: 'predictions/fastrcnn'
+  modelPath: 'predictions/fastrcnn',
+  reviewChance: 1 // Always flags for review at the moment, set to 0.01 for 1%
 };

--- a/api/handlers/__test__/interpret.test.ts
+++ b/api/handlers/__test__/interpret.test.ts
@@ -66,6 +66,21 @@ describe('interpret', () => {
     expect(response.statusCode).toEqual(404);
   });
 
+  // it('should send a test record to the queue if our random number is below the supplied threshold', async () => {
+  //     const mockMath = Object.create(global.Math);
+  //     mockMath.random = () => 0.005;
+  //     global.Math = mockMath;
+
+
+  //   })
+  // });
+
+  // it('should send a test record to the queue if our random number is above the supplied threshold', async () => {
+  //   const mockMath = Object.create(global.Math);
+  //   mockMath.random = () => 0.5;
+  //   global.Math = mockMath;
+  // });
+
   // it('should return an error to the user if the model fails to interpret the image', async () => {
   //   const scope = nock(process.env.ML_API_BASE as string).post(`/${config.modelPath}`).reply(503);
   //   const response = await handler(interpretEvent);

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -68,6 +68,8 @@ functions:
           path: interpret
           cors: true
           authorizer: authorizer
+    environment:
+      REVIEW_QUEUE_NAME: ${self:resources.Outputs.ReviewQueue.Value} 
   notify:
     handler: handlers/notify/handler.handler # Note - this handler is not exposed via http - it is only accessible by the state machine
     events:
@@ -108,11 +110,42 @@ custom:
     filterLocal: false
 resources:
   Outputs:
+    ReviewQueue:
+      Description: The ARN of the review queue
+      Value: ${opt:stage, 'dev'}-covid19-antibody-uk-results
     StateMachine:
       Description: The ARN of the provisioning state machine
       Value:
         Ref: DelayedNotificationDash${opt:stage, 'dev'}  # Capital letter at start for some reason #https://medium.com/@iamNoah_/invoke-aws-step-function-from-aws-lambda-using-the-serverless-framework-21b7fde38a42
   Resources:
+    ReviewQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${opt:stage, 'dev'}-covid19-antibody-uk-results
+        RedrivePolicy:
+          maxReceiveCount: 5
+          deadLetterTargetArn:
+            Fn::GetAtt: 
+              - ReviewDLQueue
+              - Arn
+    ReviewDLQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${opt:stage, 'dev'}-covid19-antibody-uk-results-dlq
+    SecondaryReviewQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${opt:stage, 'dev'}-covid19-antibody-uk-results-secondary
+        RedrivePolicy:
+          maxReceiveCount: 5
+          deadLetterTargetArn:
+            Fn::GetAtt: 
+              - SecondaryReviewDLQueue
+              - Arn
+    SecondaryReviewDLQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${opt:stage, 'dev'}-covid19-antibody-uk-results-secondary-dlq
     S3:
       Type: AWS::S3::Bucket
       Properties:
@@ -143,7 +176,6 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 2
           WriteCapacityUnits: 2
-          
     GatewayResponseDefault4XX:
       Type: 'AWS::ApiGateway::GatewayResponse'
       Properties:

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2180,9 +2180,9 @@
   integrity sha512-l2AgHXcKUwx2DsvP19wtRPqZ4NkONjmorOdq4sMcxIjqdIuuV/ULo2ftuv4NUpevwfW7Ju/UKLqo0ZXuEt/8lQ==
 
 "@types/lodash@^4.14.155":
-  version "4.14.157"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.157.tgz#fdac1c52448861dfde1a2e1515dbc46e54926dc8"
-  integrity sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==
+  version "4.14.159"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.159.tgz#61089719dc6fdd9c5cb46efc827f2571d1517065"
+  integrity sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg==
 
 "@types/long@^4.0.1":
   version "4.0.1"
@@ -2579,7 +2579,7 @@ abt-lib@./../lib:
   version "0.1.3"
   dependencies:
     "@types/lodash" "^4.14.155"
-    lodash "^4.17.15"
+    lodash "^4.17.19"
     rimraf "^3.0.2"
 
 acorn-globals@^4.1.0:

--- a/lib/dist/models/Prediction.d.ts
+++ b/lib/dist/models/Prediction.d.ts
@@ -20,4 +20,5 @@ export interface PredictionData {
     quality: Quality | null;
     extracts: Extracts;
     success: boolean;
+    predictedAt: number;
 }

--- a/lib/dist/models/Review.d.ts
+++ b/lib/dist/models/Review.d.ts
@@ -1,0 +1,13 @@
+import { PredictionResult } from "./Prediction";
+export declare type HumanResult = PredictionResult | "not_sure";
+export declare type ReviewStatus = "not_reviewed" | "awaiting_review" | "reviewed" | "awaiting_secondary_review" | "secondary_reviewed";
+export interface Review {
+    status: ReviewStatus;
+    originalResult: PredictionResult;
+    reviewedResult?: HumanResult;
+    originalResultCorrect?: Boolean;
+    reviewedAt?: number;
+    secondaryReviewedAt?: number;
+    reviewerId?: string;
+    secondaryReviewerId?: string;
+}

--- a/lib/dist/models/Review.js
+++ b/lib/dist/models/Review.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiUmV2aWV3LmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiLi4vLi4vbW9kZWxzL1Jldmlldy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiIn0=

--- a/lib/dist/models/TestRecord.d.ts
+++ b/lib/dist/models/TestRecord.d.ts
@@ -1,4 +1,5 @@
 import { PredictionData, PredictionResult } from "./Prediction";
+import { Review } from "./Review";
 export default interface TestRecord {
     guid: string;
     uploadUrl: string;
@@ -9,4 +10,5 @@ export default interface TestRecord {
     testCompleted: boolean;
     result?: PredictionResult;
     notificationSubscription?: PushSubscription;
+    review?: Review;
 }

--- a/lib/models/Prediction.ts
+++ b/lib/models/Prediction.ts
@@ -29,5 +29,6 @@ export interface PredictionData {
   confidence: Confidence | null,
   quality: Quality | null,
   extracts : Extracts,
-  success: boolean
+  success: boolean,
+  predictedAt: number
 }

--- a/lib/models/Review.ts
+++ b/lib/models/Review.ts
@@ -1,0 +1,17 @@
+import { PredictionResult } from "./Prediction";
+
+// Extend our ML results with the human ability to 
+export type HumanResult = PredictionResult | "not_sure";
+
+export type ReviewStatus = "not_reviewed" | "awaiting_review" | "reviewed" | "awaiting_secondary_review" | "secondary_reviewed";
+
+export interface Review {
+  status: ReviewStatus,
+  originalResult: PredictionResult,
+  reviewedResult?: HumanResult,
+  originalResultCorrect?: Boolean,
+  reviewedAt?: number,
+  secondaryReviewedAt?: number,
+  reviewerId?: string,
+  secondaryReviewerId?: string
+}

--- a/lib/models/Review.ts
+++ b/lib/models/Review.ts
@@ -1,6 +1,6 @@
 import { PredictionResult } from "./Prediction";
 
-// Extend our ML results with the human ability to 
+// Extend our ML results with the human ability to flag a result when they're not sure about it
 export type HumanResult = PredictionResult | "not_sure";
 
 export type ReviewStatus = "not_reviewed" | "awaiting_review" | "reviewed" | "awaiting_secondary_review" | "secondary_reviewed";

--- a/lib/models/TestRecord.ts
+++ b/lib/models/TestRecord.ts
@@ -1,4 +1,5 @@
 import { PredictionData, PredictionResult } from "./Prediction";
+import { Review } from "./Review";
 
 export default interface TestRecord {
   guid: string; // unique id for this test
@@ -9,5 +10,6 @@ export default interface TestRecord {
   predictionData?: PredictionData, // data returned from the ml model
   testCompleted: boolean, // Has the user successfully uploaded an image that met the criteria
   result?: PredictionResult, // Pull our result from prediction data to top level
-  notificationSubscription?: PushSubscription
+  notificationSubscription?: PushSubscription,
+  review?: Review
 }

--- a/take-test-app/yarn.lock
+++ b/take-test-app/yarn.lock
@@ -1633,9 +1633,9 @@
   integrity sha512-Zst90IcBX5wnwSu7CAS0vvJkTjTELY4ssKbHiTnGcJgi170uiS8yQDdc3v6S77bRqYQIN1App5a1Pc2lceE5/g==
 
 "@types/lodash@^4.14.155":
-  version "4.14.157"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.157.tgz#fdac1c52448861dfde1a2e1515dbc46e54926dc8"
-  integrity sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==
+  version "4.14.159"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.159.tgz#61089719dc6fdd9c5cb46efc827f2571d1517065"
+  integrity sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg==
 
 "@types/minimatch@*":
   version "3.0.3"


### PR DESCRIPTION
## Context

We need to send a random sample set of interpreted images to the human review service.

## Changes proposed in this pull request

We add SQS infra for two queues, as well as a review status field on the test record, which handles the various ids and dates for recording the review process. Once an image is successfully interpreted, we randomly select a configurable % of the images and push the guid of those images to the first queue, to be consumed by the reviewer app.

## Guidance to review

Go through a photo upload, and check a new message appears in the results queue in SQS.

## Link to Jira task

https://bluesquirrel.atlassian.net/jira/software/projects/LDAT/issues/LDAT-250


