### PR TITLE
[LDAT-229] Implement next result to review

### DIFF
--- a/lib/dist/requests/NextResult.d.ts
+++ b/lib/dist/requests/NextResult.d.ts
@@ -1,0 +1,3 @@
+export interface NextResultResponse {
+    url: string;
+}

--- a/lib/dist/requests/NextResult.js
+++ b/lib/dist/requests/NextResult.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiTmV4dFJlc3VsdC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uL3JlcXVlc3RzL05leHRSZXN1bHQudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiJ9

--- a/reviewer-app/package.json
+++ b/reviewer-app/package.json
@@ -53,7 +53,7 @@
     "@types/react-router-dom": "^5.1.5",
     "jest": "^24.0.0",
     "jest-puppeteer": "^4.4.0",
-    "nock": "^13.0.2",
+    "nock": "^13.0.4",
     "node-sass": "^4.14.1",
     "puppeteer": "^3.3.0",
     "ts-jest": "^26.1.0",

--- a/reviewer-app/src/api/config.ts
+++ b/reviewer-app/src/api/config.ts
@@ -1,0 +1,3 @@
+export default {
+  apiBase: `${process.env.REACT_APP_API_BASE}/${process.env.REACT_APP_STAGE}`,
+};

--- a/reviewer-app/src/api/testApi.test.ts
+++ b/reviewer-app/src/api/testApi.test.ts
@@ -1,11 +1,57 @@
-import testApi from './testApi';
+import testApi, { HTTPError } from "./testApi";
+import nock from "nock";
 
-describe('testApi', () => {
-  describe('nextResultToReview', () => {
-    it('returns a hardcoded URL', async () => {
-      const result = await testApi().nextResultToReview();
+describe("testApi", () => {
+  const apiBase = "http://baseurl.com";
+  const corsHeaders = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+    "Content-Type": "application/json",
+  };
 
-      expect(result.url).toEqual("https://cataas.com/cat");
+  beforeEach(() => {
+    nock(apiBase).options(/.*/).reply(200, {}, corsHeaders);
+  });
+
+  describe("nextResultToReview", () => {
+    it("Attempts to get the next result from the API", async () => {
+      const request = nock(apiBase)
+        .get("/results/next")
+        .reply(200, { cat: "meow" }, corsHeaders);
+
+      await testApi({ apiBase }).nextResultToReview();
+      expect(request.isDone()).toEqual(true);
+    });
+
+    it("Returns the response from the api", async () => {
+      nock(apiBase).get("/results/next").reply(200, { cat: "meow" }, corsHeaders);
+
+      const response = await testApi({ apiBase }).nextResultToReview();
+      expect(response).toEqual({ cat: "meow" });
+    });
+
+    describe("Error handling", () => {
+      it("throws an error", async () => {
+        nock(apiBase).get("/results/next").reply(404, {}, corsHeaders);
+
+        await expect(testApi({ apiBase }).nextResultToReview()).rejects.toThrow(
+          HTTPError
+        );
+      });
+
+      it("Returns the status code in the error", async () => {
+        nock(apiBase).get("/results/next").reply(404, {}, corsHeaders);
+        let error: HTTPError | undefined;
+
+        try {
+          await testApi({ apiBase }).nextResultToReview();
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).not.toBeUndefined();
+        expect(error?.statusCode).toBe(404);
+      });
     });
   });
 });

--- a/reviewer-app/src/api/testApi.ts
+++ b/reviewer-app/src/api/testApi.ts
@@ -1,5 +1,7 @@
+import { NextResultResponse } from "abt-lib/requests/NextResult";
+
 export interface TestApi {
-  nextResultToReview: () => Promise<any>;
+  nextResultToReview: () => Promise<NextResultResponse>;
 }
 
 export class HTTPError extends Error {
@@ -25,7 +27,7 @@ function handleErrors(response: Response): Response {
 }
 
 export default ({ apiBase }: { apiBase: string }): TestApi => ({
-  nextResultToReview: async (): Promise<any> => {
+  nextResultToReview: async () => {
     const response = await fetch(`${apiBase}/results/next`, {
       method: "GET",
       headers: {

--- a/reviewer-app/src/components/App/container.ts
+++ b/reviewer-app/src/components/App/container.ts
@@ -1,9 +1,12 @@
 import testApi, { TestApi } from "../../api/testApi";
+import config from "../../api/config";
 
 export interface AppContainer {
   testApi: TestApi;
 }
 
-const appContainer: AppContainer = { testApi };
+const appContainer: AppContainer = {
+  testApi: testApi({ apiBase: config.apiBase }),
+};
 
 export default appContainer;

--- a/reviewer-app/src/components/TestResult/TestResult.test.tsx
+++ b/reviewer-app/src/components/TestResult/TestResult.test.tsx
@@ -11,7 +11,7 @@ describe("TestResult", () => {
 
   it("Gets the next result from the testApi", async () => {
     await act(async () => {
-      await render(<TestResult container={{ testApi: () => ({ nextResultToReview: nextResultToReviewSpy }) }} />);
+      await render(<TestResult container={{ testApi: { nextResultToReview: nextResultToReviewSpy } }} />);
     });
 
     expect(nextResultToReviewSpy).toHaveBeenCalled();
@@ -21,7 +21,7 @@ describe("TestResult", () => {
     let testResult;
 
     await act(async () => {
-      testResult = await render(<TestResult container={{ testApi: () => ({ nextResultToReview: nextResultToReviewSpy }) }} />);
+      testResult = await render(<TestResult container={{ testApi: { nextResultToReview: nextResultToReviewSpy } }} />);
     });
 
     const testImage = await testResult.findByTestId('test-result-image');

--- a/reviewer-app/src/components/TestResult/index.tsx
+++ b/reviewer-app/src/components/TestResult/index.tsx
@@ -6,7 +6,7 @@ export default ({ container }: { container: AppContainer }) => {
 
   useEffect(() => {
     const getNextResult = async () => {
-      let nextResult = await container.testApi().nextResultToReview();
+      let nextResult = await container.testApi.nextResultToReview();
       setTestResult(nextResult);
     };
 

--- a/reviewer-app/yarn.lock
+++ b/reviewer-app/yarn.lock
@@ -7896,10 +7896,10 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-nock@^13.0.2:
-  version "13.0.3"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.3.tgz#9f81f04499af6a87f9c419a023920b623d715110"
-  integrity sha512-hDscKS5chEfyEiF8J1syz8mkkH6Wetp04ECAAPNdL5k6e6WmRgx9FZZNnCrjePNdykgiiPXORBcXbNmMzFOP5w==
+nock@^13.0.4:
+  version "13.0.4"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.4.tgz#9fb74db35d0aa056322e3c45be14b99105cd7510"
+  integrity sha512-alqTV8Qt7TUbc74x1pKRLSENzfjp4nywovcJgi/1aXDiUxXdt7TkruSTF5MDWPP7UoPVgea4F9ghVdmX0xxnSA==
   dependencies:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"

--- a/take-test-app/yarn.lock
+++ b/take-test-app/yarn.lock
@@ -7298,9 +7298,9 @@ lodash.uniq@^4.5.0:
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lodash@^4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 loglevel@^1.6.6:
   version "1.6.7"


### PR DESCRIPTION
## Context

The API now has the `results/next` endpoint implemented, this pull request replaces the hardcoded endpoint with actually calling the API.

## Changes proposed in this pull request

- Add .env files for the api
- Add configs for the api
- Change the endpoint to be the correct url to pull from our API

## Guidance to review

Run the full stack locally, submit an image to the API, and then load the reviewer app and see the picture pop up.

## Link to Jira task

https://bluesquirrel.atlassian.net/browse/LDAT-229

