### PR TITLE
[LDAT-256] Sign in flow

### DIFF
--- a/reviewer-app/package.json
+++ b/reviewer-app/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@aws-amplify/ui-components": "^0.6.2",
-    "@aws-amplify/ui-react": "^0.2.15",
     "@sentry/browser": "^5.17.0",
     "abt-lib": "./../lib",
     "aws-amplify": "^3.0.24",

--- a/reviewer-app/src/api/authenticationApi/authenticationApi.ts
+++ b/reviewer-app/src/api/authenticationApi/authenticationApi.ts
@@ -1,0 +1,31 @@
+export interface SignInResponse {
+  user: any;
+  successful: boolean;
+  requiresNewPassword: boolean;
+  errors?: string[];
+}
+
+export interface NewPasswordResponse {
+  successful: boolean;
+  errors?: string[];
+}
+
+export interface AuthenticationApi {
+  signIn: ({
+    username,
+    password,
+  }: {
+    username: string;
+    password: string;
+  }) => Promise<SignInResponse>;
+
+  newPassword: ({
+    user,
+    newPassword,
+  }: {
+    user: any;
+    newPassword: string;
+  }) => Promise<NewPasswordResponse>;
+
+  signOut: Function;
+}

--- a/reviewer-app/src/api/authenticationApi/cognitoAuthenticationApi.ts
+++ b/reviewer-app/src/api/authenticationApi/cognitoAuthenticationApi.ts
@@ -1,0 +1,52 @@
+import { Auth } from "aws-amplify";
+import {
+  AuthenticationApi,
+  SignInResponse,
+  NewPasswordResponse,
+} from "./authenticationApi";
+
+const authenticationApi: AuthenticationApi = {
+  signIn: async ({ username, password }) => {
+    let response: SignInResponse = {
+      user: undefined,
+      successful: false,
+      requiresNewPassword: false,
+    };
+
+    await Auth.signIn({ username, password })
+      .then((user) => {
+        response.user = user;
+        response.successful = true;
+        response.requiresNewPassword =
+          user.challengeName === "NEW_PASSWORD_REQUIRED";
+      })
+      .catch((err) => {
+        response.successful = false;
+        response.errors = [err.message];
+      });
+    return response;
+  },
+
+  newPassword: async ({ user, newPassword }) => {
+    let response: NewPasswordResponse = {
+      successful: false,
+    };
+
+    await Auth.completeNewPassword(user, newPassword, {})
+      .then(() => {
+        response.successful = true;
+      })
+      .catch((error) => {
+        response.successful = false;
+        response.errors = [error.message];
+      });
+
+    return response;
+  },
+
+  signOut: async () => {
+    return Auth.signOut();
+  },
+};
+
+export default authenticationApi;

--- a/reviewer-app/src/components/App/App.tsx
+++ b/reviewer-app/src/components/App/App.tsx
@@ -8,7 +8,7 @@ import { Row, Col } from 'nhsuk-react-components';
 function App() {
   return (
     <Layout>
-      <CognitoLogin>
+      <CognitoLogin container={appContainer}>
         <Row>
           <Col width="two-thirds">
             <TestResult container={appContainer} />

--- a/reviewer-app/src/components/App/container.ts
+++ b/reviewer-app/src/components/App/container.ts
@@ -1,67 +1,22 @@
 import testApi, { TestApi } from "../../api/testApi";
+import cognitoAuthenticationApi from "../../api/authenticationApi/cognitoAuthenticationApi";
 import config from "../../api/config";
 import { Auth } from "aws-amplify";
+import { AuthenticationApi } from "api/authenticationApi/authenticationApi";
 
 export interface AppContainer {
   testApi: TestApi;
+  authenticationApi: AuthenticationApi;
   getCurrentUserDetails: any;
-  authenticationApi: any;
-}
-
-interface SignInResponse {
-  user: any;
-  successful: boolean;
-  requiresNewPassword: boolean;
-  errors: any[];
 }
 
 const appContainer: AppContainer = {
   testApi: testApi({ apiBase: config.apiBase }),
+  authenticationApi: cognitoAuthenticationApi,
   getCurrentUserDetails: async () => {
     return Auth.currentAuthenticatedUser()
       .then((user) => ({ user, loggedIn: true }))
       .catch(() => ({ loggedIn: false }));
-  },
-  authenticationApi: {
-    signIn: async ({ username, password }): Promise<SignInResponse> => {
-      let response: SignInResponse = {
-        user: undefined,
-        successful: false,
-        requiresNewPassword: false,
-        errors: [],
-      };
-      await Auth.signIn({ username, password })
-        .then((user) => {
-          response.user = user;
-          response.successful = true;
-          response.requiresNewPassword =
-            user.challengeName === "NEW_PASSWORD_REQUIRED";
-        })
-        .catch((err) => {
-          response.successful = false;
-          response.errors.push(err.message);
-        });
-      return response;
-    },
-    newPassword: async ({ user, newPassword }) => {
-      let response = {
-        successful: false,
-      };
-
-      await Auth.completeNewPassword(user, newPassword, {})
-        .then(() => {
-          response.successful = true;
-        })
-        .catch((error) => {
-          console.log(error);
-          response.successful = false;
-        });
-
-      return response;
-    },
-    signOut: async () => {
-      return Auth.signOut();
-    },
   },
 };
 

--- a/reviewer-app/src/components/App/container.ts
+++ b/reviewer-app/src/components/App/container.ts
@@ -1,12 +1,68 @@
 import testApi, { TestApi } from "../../api/testApi";
 import config from "../../api/config";
+import { Auth } from "aws-amplify";
 
 export interface AppContainer {
   testApi: TestApi;
+  getCurrentUserDetails: any;
+  authenticationApi: any;
+}
+
+interface SignInResponse {
+  user: any;
+  successful: boolean;
+  requiresNewPassword: boolean;
+  errors: any[];
 }
 
 const appContainer: AppContainer = {
   testApi: testApi({ apiBase: config.apiBase }),
+  getCurrentUserDetails: async () => {
+    return Auth.currentAuthenticatedUser()
+      .then((user) => ({ user, loggedIn: true }))
+      .catch(() => ({ loggedIn: false }));
+  },
+  authenticationApi: {
+    signIn: async ({ username, password }): Promise<SignInResponse> => {
+      let response: SignInResponse = {
+        user: undefined,
+        successful: false,
+        requiresNewPassword: false,
+        errors: [],
+      };
+      await Auth.signIn({ username, password })
+        .then((user) => {
+          response.user = user;
+          response.successful = true;
+          response.requiresNewPassword =
+            user.challengeName === "NEW_PASSWORD_REQUIRED";
+        })
+        .catch((err) => {
+          response.successful = false;
+          response.errors.push(err.message);
+        });
+      return response;
+    },
+    newPassword: async ({ user, newPassword }) => {
+      let response = {
+        successful: false,
+      };
+
+      await Auth.completeNewPassword(user, newPassword, {})
+        .then(() => {
+          response.successful = true;
+        })
+        .catch((error) => {
+          console.log(error);
+          response.successful = false;
+        });
+
+      return response;
+    },
+    signOut: async () => {
+      return Auth.signOut();
+    },
+  },
 };
 
 export default appContainer;

--- a/reviewer-app/src/components/CognitoLogin/CognitoLogin.test.tsx
+++ b/reviewer-app/src/components/CognitoLogin/CognitoLogin.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, fireEvent } from "@testing-library/react";
+import CognitoLogin from '.';
+import { act } from 'react-dom/test-utils';
+import { AppContainer } from 'components/App/container';
+
+describe("<CognitoLogin>", () => {
+  const userStub = { signInUserSession: { accessToken: { payload: { "cognito:groups": ["cat-gang"] } } } };
+  let login;
+  let container: AppContainer = {
+    getCurrentUserDetails: () => { },
+    testApi: {} as any,
+    authenticationApi: {} as any
+  };
+
+  const renderLogin = async () => {
+    await act(async () => {
+      login = await render(<CognitoLogin container={container} ><div data-testid="find-me"></div></CognitoLogin>);
+    });
+  };
+
+  it("Gets the current login details", async () => {
+    const getCurrentUserDetailsStub = jest.fn(() => new Promise((resolve) => resolve({ user: userStub, loggedIn: true })));
+    container.getCurrentUserDetails = getCurrentUserDetailsStub;
+
+    await renderLogin();
+    expect(getCurrentUserDetailsStub).toHaveBeenCalled();
+  });
+
+  describe("When the user is already logged in", () => {
+    beforeEach(async () => {
+      const getCurrentUserDetailsStub = jest.fn(() => new Promise((resolve) => resolve({ user: userStub, loggedIn: true })));
+      const signOutStub = jest.fn();
+      container.getCurrentUserDetails = getCurrentUserDetailsStub;
+      container.authenticationApi = { signOut: signOutStub };
+
+      await renderLogin();
+    });
+
+    it("Displays the child contents", async () => {
+      const content = await login.findByTestId("find-me");
+      expect(content).toBeInTheDocument();
+    });
+
+    it("Displays the sign out button", async () => {
+      const signOutButton = await login.findByText("Sign out");
+      expect(signOutButton).toBeInTheDocument();
+    });
+
+    it("Allows the user to sign out", async () => {
+      await act(async () => {
+        const signOutButton = await login.findByText("Sign out");
+        fireEvent.click(signOutButton);
+      });
+
+      expect(container.authenticationApi.signOut).toHaveBeenCalled();
+    });
+
+    it("Displays the login form after sign out", async () => {
+      await act(async () => {
+
+        const signOutButton = await login.findByText("Sign out");
+        fireEvent.click(signOutButton);
+      });
+
+      const loginForm = await login.findByTestId("login-form");
+      expect(loginForm).toBeInTheDocument();
+    });
+  });
+
+  describe("When the user is not already logged in", () => {
+    it("Does not display the child contents", async () => {
+      const getCurrentUserDetailsStub = jest.fn(() => new Promise((resolve) => resolve({ loggedIn: false })));
+      container.getCurrentUserDetails = getCurrentUserDetailsStub;
+
+      await renderLogin();
+
+      const content = await login.queryByTestId("find-me");
+      expect(content).not.toBeInTheDocument();
+    });
+  });
+
+  describe("State: Login", () => {
+    const loginWithDetails = async (loginComponent, username, password) => {
+      const usernameInput = await loginComponent.findByLabelText("Username");
+      const passwordInput = await loginComponent.findByLabelText("Password");
+      const continueButton = await loginComponent.findByText("Continue");
+      fireEvent.change(usernameInput, { target: { value: username } });
+      fireEvent.change(passwordInput, { target: { value: password } });
+      fireEvent.submit(continueButton);
+    };
+
+    beforeEach(() => {
+      const getCurrentUserDetailsStub = jest.fn(() => new Promise((resolve) => resolve({ loggedIn: false })));
+      container.getCurrentUserDetails = getCurrentUserDetailsStub;
+    });
+
+    it("Logs the user in on the authentication API", async () => {
+      const signInSpy = jest.fn(() => new Promise((resolve) => resolve({ user: userStub, successful: true })));
+      const authenticationApi = { signIn: signInSpy };
+      container = { ...container, authenticationApi };
+
+      await act(async () => {
+        await renderLogin();
+        await loginWithDetails(login, "meow", "cat");
+      });
+
+      expect(signInSpy).toHaveBeenCalledWith({ username: "meow", password: "cat" });
+    });
+
+    describe("When the login is successful", () => {
+      it("Displays the child content", async () => {
+        const signInSpy = jest.fn(() => new Promise((resolve) => resolve({ user: userStub, successful: true })));
+        const authenticationApi = { signIn: signInSpy };
+        container = { ...container, authenticationApi };
+
+        await act(async () => {
+          await renderLogin();
+          await loginWithDetails(login, "meow", "cat");
+        });
+
+        const content = await login.findByTestId("find-me");
+        expect(content).not.toBeUndefined();
+      });
+    });
+
+    describe("When the user has to change their password on first login", () => {
+      it("Displays the new password form", async () => {
+        const signInSpy = jest.fn(() => new Promise((resolve) => resolve({ user: userStub, successful: true, requiresNewPassword: true })));
+        const authenticationApi = { signIn: signInSpy };
+        container = { ...container, authenticationApi };
+
+        await act(async () => {
+          await renderLogin();
+          await loginWithDetails(login, "meow", "cat");
+        });
+
+        const content = await login.findByTestId("new-password-form");
+        expect(content).toBeInTheDocument();
+      });
+
+      it("Allows the user to change their password", async () => {
+        const signInSpy = jest.fn(() => new Promise((resolve) => resolve({ user: userStub, successful: true, requiresNewPassword: true })));
+        const newPasswordSpy = jest.fn(() => new Promise((resolve) => resolve({ successful: true })));
+
+        const authenticationApi = { signIn: signInSpy, newPassword: newPasswordSpy };
+        container = { ...container, authenticationApi };
+
+        await act(async () => {
+          await renderLogin();
+          await loginWithDetails(login, "meow", "cat");
+          const newPasswordInput = await login.findByLabelText("New password");
+          const continueButton = await login.findByText("Continue");
+          fireEvent.change(newPasswordInput, { target: { value: "woof" } });
+          fireEvent.submit(continueButton);
+        });
+
+        expect(newPasswordSpy).toHaveBeenCalledWith({ user: userStub, newPassword: "woof" });
+      });
+    });
+  });
+});

--- a/reviewer-app/src/components/CognitoLogin/index.tsx
+++ b/reviewer-app/src/components/CognitoLogin/index.tsx
@@ -8,7 +8,7 @@ type CognitoLoginProps = {
   children: React.ReactNode
 };
 
-const New = ({ container, children }: CognitoLoginProps) => {
+export default ({ container, children }: CognitoLoginProps) => {
   const [loading, setLoading] = React.useState<boolean>(true);
   const [authState, setAuthState] = React.useState<string>("login");
   const [user, setUser] = React.useState<any>(undefined);
@@ -115,5 +115,3 @@ const New = ({ container, children }: CognitoLoginProps) => {
     </Row>
   </>;
 };
-
-export default New;

--- a/reviewer-app/src/components/CognitoLogin/index.tsx
+++ b/reviewer-app/src/components/CognitoLogin/index.tsx
@@ -1,49 +1,119 @@
-import React from "react";
-import { AmplifyAuthenticator, AmplifySignOut, AmplifySignIn } from "@aws-amplify/ui-react";
-import { Row, Col, Label } from "nhsuk-react-components";
-import { AuthState, onAuthUIStateChange } from "@aws-amplify/ui-components";
+import React, { useEffect } from "react";
+import { Row, Col, Label, Input } from "nhsuk-react-components";
+import { Button } from "nhsuk-react-components";
+import { AppContainer } from "components/App/container";
 
-export default ({ children }) => {
-  const [authState, setAuthState] = React.useState<AuthState>();
-  const [user, setUser] = React.useState<any>();
+type CognitoLoginProps = {
+  container: AppContainer,
+  children: React.ReactNode
+};
 
-  React.useEffect(() => {
-    return onAuthUIStateChange((nextAuthState, authData) => {
-      setAuthState(nextAuthState);
-      setUser(authData);
-    });
-  }, []);
+const New = ({ container, children }: CognitoLoginProps) => {
+  const [loading, setLoading] = React.useState<boolean>(true);
+  const [authState, setAuthState] = React.useState<string>("login");
+  const [user, setUser] = React.useState<any>(undefined);
+  const [username, setUsername] = React.useState<string>("");
+  const [password, setPassword] = React.useState<string>("");
+  const [newPassword, setNewPassword] = React.useState<string>("");
 
-  if (authState === AuthState.SignedIn && user) {
+  const onLogin = async (e) => {
+    e.preventDefault();
+    const signInResponse = await container.authenticationApi.signIn({ username, password });
+    if (signInResponse.successful && signInResponse.requiresNewPassword) {
+      setUser(signInResponse.user);
+      setAuthState("newPassword");
+    } else if (signInResponse.successful) {
+      setUser(signInResponse.user);
+      setAuthState("loggedIn");
+    }
+  };
+
+  const onNewPassword = async (e) => {
+    e.preventDefault();
+    const newPasswordResponse = await container.authenticationApi.newPassword({ user, newPassword });
+    if (newPasswordResponse.successful) {
+      setAuthState("loggedIn");
+    }
+  };
+
+  const signOut = async () => {
+    await container.authenticationApi.signOut();
+    setAuthState("login");
+  };
+
+  useEffect(() => {
+    const getInitialAuthState = async () => {
+      const response = await container.getCurrentUserDetails();
+      if (response.loggedIn) {
+        setAuthState("loggedIn");
+        setUser(response.user);
+      }
+
+      setLoading(false);
+    };
+    getInitialAuthState();
+  }, [container]);
+
+  if (loading) {
+    return <div data-testid="loading" />;
+  }
+
+  if (authState === "loggedIn") {
+    return <>
+      <Row>
+        <Col width="two-thirds">
+          <Button onClick={signOut}>Sign out</Button>
+          <Label size="l">User group: {user.signInUserSession.accessToken.payload["cognito:groups"][0]}</Label>
+        </Col>
+      </Row>
+      {children}
+    </>;
+  }
+
+  if (authState === "newPassword") {
     return (
       <>
         <Row>
           <Col width="two-thirds">
-            <AmplifySignOut />
-            <Label size="l">
-              User group:{" "}
-              {user.signInUserSession.accessToken.payload["cognito:groups"][0]}
-            </Label>
-          </Col>
-        </Row>
-        {children}
-      </>
-    );
-  } else {
-    return (
-      <>
-        <Row>
-          <Col width="two-thirds">
-            <AmplifyAuthenticator usernameAlias="email">
-              <AmplifySignIn
-                headerText="Sign in to the reviewer service"
-                slot="sign-in"
-                hideSignUp
-              />
-            </AmplifyAuthenticator>
+            <form
+              onSubmit={onNewPassword}
+              data-testid="new-password-form"
+            >
+              <Input
+                type="password"
+                onChange={(e) => setNewPassword(e.currentTarget.value)}
+                label="New password"
+                value={newPassword} />
+              <Button type="submit">Continue</Button>
+            </form>
           </Col>
         </Row>
       </>
     );
   }
+
+  return <>
+    <Row>
+      <Col width="two-thirds">
+        <form
+          onSubmit={onLogin}
+          data-testid="login-form"
+        >
+          <Input
+            type="text"
+            onChange={(e) => setUsername(e.currentTarget.value)}
+            label="Username"
+            value={username} />
+          <Input
+            type="password"
+            onChange={(e) => setPassword(e.currentTarget.value)}
+            label="Password"
+            value={password} />
+          <Button type="submit">Continue</Button>
+        </form>
+      </Col>
+    </Row>
+  </>;
 };
+
+export default New;

--- a/reviewer-app/src/index.tsx
+++ b/reviewer-app/src/index.tsx
@@ -15,12 +15,6 @@ Amplify.configure({
 
     // OPTIONAL - Amazon Cognito Web Client ID (26-char alphanumeric string)
     userPoolWebClientId: process.env.REACT_APP_USER_POOL_WEB_CLIENT_ID,
-
-    // OPTIONAL - Enforce user authentication prior to accessing AWS resources or not
-    mandatorySignIn: true,
-
-    // OPTIONAL - Manually set the authentication flow type. Default is 'USER_SRP_AUTH'
-    authenticationFlowType: 'USER_PASSWORD_AUTH',
   }
 });
 

--- a/reviewer-app/yarn.lock
+++ b/reviewer-app/yarn.lock
@@ -144,21 +144,6 @@
     events "^3.1.0"
     sinon "^7.5.0"
 
-"@aws-amplify/ui-components@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ui-components/-/ui-components-0.6.2.tgz#5266ded0d1b057cea6776b14e6d9ccf2c5bcefd4"
-  integrity sha512-CbOWMnpyIf7bTzjNdSrQScRqzq7FvAyxh9IEz9wTVXWOThezfKQbMDUvdBbu8N9kt5sZRfshrWYEzrdJjQ595A==
-  dependencies:
-    qrcode "^1.4.4"
-    uuid "^8.2.0"
-
-"@aws-amplify/ui-react@^0.2.15":
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ui-react/-/ui-react-0.2.15.tgz#70968f6a79c22e1ec6d425f15c9e2b1431d2ff32"
-  integrity sha512-ohgAi3oCtsi89kBCl/i1xcZwv0H+nGlf0mn1qpj5JUuJdV9uwk0UOK3iNEdJGjyC6/ZvlsLDtRkEQ8VUOA3jKA==
-  dependencies:
-    "@aws-amplify/ui-components" "^0.6.2"
-
 "@aws-amplify/ui@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@aws-amplify/ui/-/ui-2.0.2.tgz#56bfc3674454f2a12d1cec247f38a444aa13ea09"
@@ -4251,30 +4236,12 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-alloc-unsafe@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
-  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
-
-buffer-alloc@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
-  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
-  dependencies:
-    buffer-alloc-unsafe "^1.1.0"
-    buffer-fill "^1.0.0"
-
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
-buffer-fill@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
-  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
-
-buffer-from@1.x, buffer-from@^1.0.0, buffer-from@^1.1.1:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -4307,7 +4274,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.2.1, buffer@^5.4.3, buffer@^5.5.0:
+buffer@^5.2.1, buffer@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
   integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
@@ -5521,11 +5488,6 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
-
-dijkstrajs@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.1.tgz#d3cd81221e3ea40742cfcde556d4e99e98ddc71b"
-  integrity sha1-082BIh4+pAdCz83lVtTpnpjdxxs=
 
 dir-glob@2.0.0:
   version "2.0.0"
@@ -7850,11 +7812,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isarray@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -10167,11 +10124,6 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-pngjs@^3.3.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
-  integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
-
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
@@ -11056,19 +11008,6 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
-
-qrcode@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.4.4.tgz#f0c43568a7e7510a55efc3b88d9602f71963ea83"
-  integrity sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==
-  dependencies:
-    buffer "^5.4.3"
-    buffer-alloc "^1.2.0"
-    buffer-from "^1.1.1"
-    dijkstrajs "^1.0.1"
-    isarray "^2.0.1"
-    pngjs "^3.3.0"
-    yargs "^13.2.4"
 
 qs@6.7.0:
   version "6.7.0"
@@ -13292,11 +13231,6 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.2.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.2.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
-
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
@@ -13897,7 +13831,7 @@ yargs@12.0.5:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@^13.2.4, yargs@^13.3.0, yargs@^13.3.2:
+yargs@^13.3.0, yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
   integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==


### PR DESCRIPTION
## Context

The build in amplify ui components don't conform to the NHS Design system - we needed to ensure we had a flexible login UI to handle when designs change.

This is the first of a few PRs to migrate this.

## Changes proposed in this pull request

- Uses slightly more secure login methods for cognito
- Removes amplify ui components for login
- Reimplements the `CognitoLogin` component with custom logic
  - Currently supports:
    - Initial login & initial password setting
    - Logging in existing users
- Add authentication API interface & cognito implementaion

## Guidance to review

- Check out the branch
- Create a new user in cognito
  - **Assign it a group**
- Login, create your new password
- Logout
- Login again

## Link to Jira task

https://bluesquirrel.atlassian.net/browse/LDAT-256

<!-- ## Things to check - omitted for now 

- [ ] Example to check
- [ ] Example two

-->

