### PR TITLE
[LDAT-257] Send cognito JWT token to test api

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -166,7 +166,7 @@ resources:
           Ref: ApiGatewayRestApi
         Type: COGNITO_USER_POOLS
         ProviderARNs:
-          - arn:aws:cognito-idp:eu-west-2:877130379437:userpool/eu-west-2_En3UNP0Yw
+          - arn:aws:cognito-idp:eu-west-2:877130379437:userpool/eu-west-2_14WRfl09I
     ClientS3:
       Type: AWS::S3::Bucket
       Properties:

--- a/reviewer-app/src/api/testApi/testApi.ts
+++ b/reviewer-app/src/api/testApi/testApi.ts
@@ -1,4 +1,5 @@
 import { NextResultResponse } from "abt-lib/requests/NextResult";
+import { Auth } from "aws-amplify";
 
 export interface TestApi {
   nextResultToReview: () => Promise<NextResultResponse>;
@@ -28,10 +29,12 @@ function handleErrors(response: Response): Response {
 
 export default ({ apiBase }: { apiBase: string }): TestApi => ({
   nextResultToReview: async () => {
+    const session = await Auth.currentSession();
     const response = await fetch(`${apiBase}/results/next`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `Bearer ${session.getIdToken().getJwtToken()}`
       },
     }).then(handleErrors);
 

--- a/reviewer-app/src/components/App/container.ts
+++ b/reviewer-app/src/components/App/container.ts
@@ -1,4 +1,4 @@
-import testApi, { TestApi } from "../../api/testApi";
+import testApi, { TestApi } from "../../api/testApi/testApi";
 import cognitoAuthenticationApi from "../../api/authenticationApi/cognitoAuthenticationApi";
 import config from "../../api/config";
 import { Auth } from "aws-amplify";


### PR DESCRIPTION
## Context

The Test API now authenticates against Cognito, as such we need to send the Cognito users token over to authenticate

## Changes proposed in this pull request

- Send the authentication token from cognito to the `/next` endpoint on the API

## Guidance to review

- Login to the application
- Ensure a valid jwt token is sent over the API

## Link to Jira task

https://bluesquirrel.atlassian.net/browse/LDAT-257

<!-- ## Things to check - omitted for now 

- [ ] Example to check
- [ ] Example two

-->

